### PR TITLE
Remove JH login parameter from call to main app.

### DIFF
--- a/sandstone_jupyterhub_login/__init__.py
+++ b/sandstone_jupyterhub_login/__init__.py
@@ -17,11 +17,11 @@ def run_server():
     parser.add_argument('--user')
     args = parser.parse_args()
 
-    # Set hub api url environment variable to be read by the login handler
+    # Set hub environment variables to be read by the login handler
     os.environ['JUPYTERHUB_API_URL'] = args.hub_api_url[1:-1]
+    os.environ['JUPYTERHUB_COOKIE_NAME'] = args.cookie_name[1:-1]
 
     # Remove extraneous quotes from string
     prefix = args.base_url[1:-1]
-    cookie_name = args.cookie_name[1:-1]
 
-    sandstone.app.main(port=args.port,prefix=prefix,cookie_name=cookie_name)
+    sandstone.app.main(port=args.port,prefix=prefix)

--- a/sandstone_jupyterhub_login/handlers.py
+++ b/sandstone_jupyterhub_login/handlers.py
@@ -15,7 +15,6 @@ class JupyterHubLoginHandler(BaseHandler):
 
         url = '{hub_url}/authorizations/cookie/{cookie_name}/{cookie_value}'.format(
             hub_url=hub_api_url,
-            token=api_token,
             cookie_name=cookie_name,
             cookie_value=encrypted_cookie,
         )
@@ -49,11 +48,11 @@ class JupyterHubLoginHandler(BaseHandler):
 
         api_token = os.environ['JUPYTERHUB_API_TOKEN']
         hub_api_url = os.environ['JUPYTERHUB_API_URL']
+        cookie_name = os.environ['JUPYTERHUB_COOKIE_NAME']
 
         # Has user deconfigured certificate verification?
         verify = getattr(settings,'VERIFY_JH_CERT',True)
 
-        cookie_name = self.settings['cookie_name']
         encrypted_cookie = self.get_cookie(cookie_name)
 
         if encrypted_cookie:


### PR DESCRIPTION
This is a small change to your patch, meant to maintain separation of concerns between JupyterHub login and the Sandstone main app. `cookie-name` is set on the process environment instead of being passed as a parameter to `sandstone.app.main`.